### PR TITLE
remove install_plugins from compile phase

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -45,7 +45,8 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
 
   def compile
     instrument "rails2.compile" do
-      install_plugins
+      # XXX(dmauldin): we're just fine without the plugins, thanks
+      # install_plugins
       super
     end
   end


### PR DESCRIPTION
The plugins being removed are borking our logging by stomping on the Rails.logger object we've creating during configuration.
